### PR TITLE
Lost state add native tabbar

### DIFF
--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -72,7 +72,6 @@ struct RootView: View {
                     .tag(TabbedItems.settings)
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-                
  
             ZStack() {
                 TabBarTopBorderVectorView()
@@ -101,8 +100,6 @@ struct RootView: View {
                         } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item))
                         } .offset(y: 4)
                     }
-                    
-                    
                 }.frame(height: 49)
             }
             .background(.white)

--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -60,21 +60,21 @@ struct RootView: View {
     var goalsService: GoalsService
     
     var body: some View {
-        VStack(spacing: 0.0) {
-            ZStack(alignment: .bottom){
-                TabView(selection: $selectedTab) {
-                    HomeView(homeViewModel: homeViewModel)
-                        .tag(TabbedItems.home)
-                    StatisticsView()
-                        .tag(TabbedItems.stats)
-                    HistoryView(historyViewModel: historyViewModel)
-                        .tag(TabbedItems.history)
-                    SettingsView()
-                        .tag(TabbedItems.settings)
-                }
-            }.frame(maxWidth: .infinity, maxHeight: .infinity)
+        ZStack(alignment: .bottom) {
+            TabView(selection: $selectedTab) {
+                HomeView(homeViewModel: homeViewModel)
+                    .tag(TabbedItems.home)
+                StatisticsView()
+                    .tag(TabbedItems.stats)
+                HistoryView(historyViewModel: historyViewModel)
+                    .tag(TabbedItems.history)
+                SettingsView()
+                    .tag(TabbedItems.settings)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                
  
-            ZStack {
+            ZStack() {
                 TabBarTopBorderVectorView()
                     .offset(y: -26.5)
                 HStack {
@@ -105,7 +105,7 @@ struct RootView: View {
                     
                 }.frame(height: 49)
             }
-            .background(.clear)
+            .background(.white)
         }
     }
 }

--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -17,7 +17,7 @@ struct HistoryView2: View {
 
 
 enum TabbedItems: Int, CaseIterable {
-    case home
+    case home = 0
     case stats
     case history
     case settings
@@ -51,7 +51,7 @@ enum TabbedItems: Int, CaseIterable {
 
 
 struct RootView: View {
-    @State var selectedTab: TabbedItems = .home
+    @State var selectedTab = 0
     @ObservedObject var homeViewModel: HomeViewModel
     @ObservedObject var historyViewModel: HistoryViewModel
     
@@ -61,20 +61,18 @@ struct RootView: View {
     
     var body: some View {
         VStack(spacing: 0.0) {
-            Group {
-                switch selectedTab {
-                case .home:
+            ZStack(alignment: .bottom){
+                TabView(selection: $selectedTab) {
                     HomeView(homeViewModel: homeViewModel)
-                case .stats:
+                        .tag(0)
                     StatisticsView()
-                case .history:
+                        .tag(1)
                     HistoryView(historyViewModel: historyViewModel)
-                case .settings:
+                        .tag(2)
                     SettingsView()
+                        .tag(3)
                 }
-            }
-            .frame(maxWidth: .infinity,
-                   maxHeight: .infinity)
+            }.frame(maxWidth: .infinity, maxHeight: .infinity)
  
             ZStack {
                 TabBarTopBorderVectorView()
@@ -82,9 +80,8 @@ struct RootView: View {
                 HStack {
                     ForEach((TabbedItems.allCases.prefix(2)), id: \.self){ item in
                         Button {
-                            selectedTab = item
-                        } label: {
-                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item))
+                            selectedTab = item.rawValue
+                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item.rawValue))
                         } .offset(y: 4)
                     }
                     
@@ -100,9 +97,8 @@ struct RootView: View {
 
                     ForEach((TabbedItems.allCases.suffix(2)), id: \.self){ item in
                         Button {
-                            selectedTab = item
-                        } label: {
-                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item))
+                            selectedTab = item.rawValue
+                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item.rawValue))
                         } .offset(y: 4)
                     }
                     

--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -17,7 +17,7 @@ struct HistoryView2: View {
 
 
 enum TabbedItems: Int, CaseIterable {
-    case home = 0
+    case home
     case stats
     case history
     case settings
@@ -51,7 +51,7 @@ enum TabbedItems: Int, CaseIterable {
 
 
 struct RootView: View {
-    @State var selectedTab = 0
+    @State var selectedTab: TabbedItems = .home
     @ObservedObject var homeViewModel: HomeViewModel
     @ObservedObject var historyViewModel: HistoryViewModel
     
@@ -64,13 +64,13 @@ struct RootView: View {
             ZStack(alignment: .bottom){
                 TabView(selection: $selectedTab) {
                     HomeView(homeViewModel: homeViewModel)
-                        .tag(0)
+                        .tag(TabbedItems.home)
                     StatisticsView()
-                        .tag(1)
+                        .tag(TabbedItems.stats)
                     HistoryView(historyViewModel: historyViewModel)
-                        .tag(2)
+                        .tag(TabbedItems.history)
                     SettingsView()
-                        .tag(3)
+                        .tag(TabbedItems.settings)
                 }
             }.frame(maxWidth: .infinity, maxHeight: .infinity)
  
@@ -80,8 +80,8 @@ struct RootView: View {
                 HStack {
                     ForEach((TabbedItems.allCases.prefix(2)), id: \.self){ item in
                         Button {
-                            selectedTab = item.rawValue
-                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item.rawValue))
+                            selectedTab = item
+                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item))
                         } .offset(y: 4)
                     }
                     
@@ -97,8 +97,8 @@ struct RootView: View {
 
                     ForEach((TabbedItems.allCases.suffix(2)), id: \.self){ item in
                         Button {
-                            selectedTab = item.rawValue
-                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item.rawValue))
+                            selectedTab = item
+                        } label: {                            addCustomTabItem(imageName: item.iconName, title: item.title, isActive: (selectedTab == item))
                         } .offset(y: 4)
                     }
                     


### PR DESCRIPTION
Problem: Switching between tabs looses tab view state.

Changes Made:
- use original TabView instead of Group and switch with four cases for all tab view


Test Plan: 
- launch the app
- make sure you have many drinks recorded
- go to history screen
- scroll to the bottom
- switch tab to any other one
- switch back to history
- EXPECTED: history screen remains in the exact same state as before (including scrolling position).