### PR TITLE
Change appearance of the last item in the HistoryView

### DIFF
--- a/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
@@ -51,7 +51,7 @@ struct HistoryView: View {
                                 }.frame(width: bodyGeometry.size.width)
                             }.frame(width: historyViewModel.viewState.content == .notEmpty(drinkHistoryRowModels: drinkHistoryRowModels) ? bodyGeometry.size.width : nil) // Scroll View
                                 .safeAreaInset(edge: .top, content: { Spacer().frame(height: 20) })
-                                .padding(.vertical, 20)
+                                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 20) })
                         }
             }
             .toolbar { // GeometryReader

--- a/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
@@ -51,7 +51,7 @@ struct HistoryView: View {
                                 }.frame(width: bodyGeometry.size.width)
                             }.frame(width: historyViewModel.viewState.content == .notEmpty(drinkHistoryRowModels: drinkHistoryRowModels) ? bodyGeometry.size.width : nil) // Scroll View
                                 .safeAreaInset(edge: .top, content: { Spacer().frame(height: 20) })
-                                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 20) })
+                                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 40) })
                         }
             }
             .toolbar { // GeometryReader

--- a/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/HistoryView.swift
@@ -51,7 +51,7 @@ struct HistoryView: View {
                                 }.frame(width: bodyGeometry.size.width)
                             }.frame(width: historyViewModel.viewState.content == .notEmpty(drinkHistoryRowModels: drinkHistoryRowModels) ? bodyGeometry.size.width : nil) // Scroll View
                                 .safeAreaInset(edge: .top, content: { Spacer().frame(height: 20) })
-                                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: 40) })
+                                .safeAreaInset(edge: .bottom, content: { Spacer().frame(height: RootView.addButtonProtrusion) })
                         }
             }
             .toolbar { // GeometryReader

--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -59,6 +59,9 @@ struct RootView: View {
     var drinksService: DrinksService
     var goalsService: GoalsService
     
+    // protrusion of add button + some extra space
+    static let addButtonProtrusion: CGFloat = 40
+    
     var body: some View {
         VStack(spacing: 0.0) {
             Group {


### PR DESCRIPTION
Problem: 
- last cell in the scrollView was partially obstructed by the add button. This could potentially hide some necessary content from observation. 

Changes made: 
- replace padding with safeAreaInset(.bottom)
    - safe area adds some space inside the view, while padding adds space around it
    - declare the size of safeAreaInset as a constant in RootView (it owns tab bar)

Test Plan: 
- launch the app
- make sure you have many drinks recorded
- go to history screen
- scroll to the bottom
- look at the last item
- EXPECTED: the whole cell should be seen (no hidden content under the tab bar view)