### PR TITLE
Delete redundant tab bar padding 

### DIFF
--- a/units-tracking-app/units-tracking-app/PresentationLayer/HomeView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/HomeView.swift
@@ -42,8 +42,6 @@ struct HomeView: View {
                     .font(.homeScreenInfoButton)
             }
             Spacer()
-              //  .frame(height: 290)
-            Text("BOTTOM")
         }
     }
 }

--- a/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
+++ b/units-tracking-app/units-tracking-app/PresentationLayer/RootView.swift
@@ -65,7 +65,6 @@ struct RootView: View {
     static let addButtonProtrusion: CGFloat = 40
     
     var body: some View {
-        VStack(spacing: 0.0) {
             ZStack(alignment: .bottom) {
                 TabView(selection: $selectedTab) {
                     HomeView(homeViewModel: homeViewModel)
@@ -76,7 +75,6 @@ struct RootView: View {
                         .tag(TabbedItems.history)
                     SettingsView(settingsViewModel: settingsViewModel, goalsService: goalsService)
                         .tag(TabbedItems.settings)
-                }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
  


### PR DESCRIPTION
- Get rid of redundant padding at the bottom of content area.
- Delete redundant "BOTTOM" label from the home screen.